### PR TITLE
Fix wancheck to write isup lines out properly

### DIFF
--- a/supplicant_openwrt.sh
+++ b/supplicant_openwrt.sh
@@ -121,12 +121,12 @@ PASS=0
 
 while [ \$PASS -eq 0 ]
 do
-  isup=$(cat /sys/class/net/${wandevice}/operstate)
+  isup=\$(cat /sys/class/net/${wandevice}/operstate)
   logger -t DEBUG "The wan first check is \${isup}"
 
   if [ "\$isup" != "up" ]; then
     sleep 10 #sec
-    isup=$(cat /sys/class/net/${wandevice}/operstate)
+    isup=\$(cat /sys/class/net/${wandevice}/operstate)
     logger -t DEBUG "The wan second check is \${isup}"
 
     if [ "\$isup" != "up" ]; then


### PR DESCRIPTION
As originally written, when running the script, the 2x isup=$(cat /sys/class/net/${wandevice}/operstate) lines will evaluate at the time the setup script is run, throwing in whatever the state of the WAN interface is when you run the setup script.

If the interface is "up" at the time the setup script is run, then the generated script at /etc/wancheck will hardcode isup=up, and if interface is "downk" the script will hardcode isup=down, and the script won't be dynamically checking operstate.  This'll make the script always jump straight to the else at the end and do nothing if the WAN was up when you ran the setup script, or loop indefinitely if the WAN was not up when you ran the setup script.

Added in a \ before the $ on these lines so that the script that's generated at /etc/wancheck ends up with the expected "isup=$(cat /sys/class/net/eth0/operstate)"